### PR TITLE
replaced -s with -a in the 'which' command

### DIFF
--- a/bin/install.sh
+++ b/bin/install.sh
@@ -12,8 +12,8 @@ function os_type
     case `uname` in
         Linux )
             OS_LINUX=1
-            which -s yum && { OS_REDHAT=1; return; }
-            which -s apt-get && { OS_DEBIAN=1; return; }
+            which -a yum && { OS_REDHAT=1; return; }
+            which -a apt-get && { OS_DEBIAN=1; return; }
             ;;
         Darwin )
             OS_MAC=1


### PR DESCRIPTION
which command doesn't accept -s as argument : 
#which -s
Illegal option -s
Usage: /usr/bin/which [-a] args
